### PR TITLE
Update unremind command to work with reminded assignment list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UnremindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnremindCommand.java
@@ -28,17 +28,16 @@ public class UnremindCommand extends NegateCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Removes the reminder from the assignment identified by the index number "
-            + "used in the displayed assignment list."
+            + "used in the displayed reminders list."
             + " Assignments will no longer have reminders set and will be removed from the displayed reminders list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_UNREMIND_ASSIGNMENT_SUCCESS = "Removed reminder for Assignment: %1$s";
-    public static final String MESSAGE_UNREMINDED_ASSIGNMENT = "This assignment does not have reminders set.";
 
     /**
      * Constructs an UnremindCommand to remove reminders from the specified assignment.
-     * @param targetIndex index of the assignment in the filtered assignment list to remove reminders
+     * @param targetIndex index of the assignment in the reminded assignments list to remove reminders
      */
     public UnremindCommand(Index targetIndex) {
         super(targetIndex);
@@ -47,19 +46,15 @@ public class UnremindCommand extends NegateCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Assignment> lastShownList = model.getFilteredAssignmentList();
+        List<Assignment> remindedAssignmentsList = model.getRemindedAssignmentsList();
 
-        if (getTargetIndex().getZeroBased() >= lastShownList.size()) {
+        if (getTargetIndex().getZeroBased() >= remindedAssignmentsList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
 
-        Assignment assignmentToUnremind = lastShownList.get(getTargetIndex().getZeroBased());
-
-        if (!assignmentToUnremind.isReminded() && model.hasAssignment(assignmentToUnremind)) {
-            throw new CommandException(MESSAGE_UNREMINDED_ASSIGNMENT);
-        }
-
+        Assignment assignmentToUnremind = remindedAssignmentsList.get(getTargetIndex().getZeroBased());
         assert(assignmentToUnremind.isReminded());
+
         Assignment unremindedAssignment = createUnremindedAssignment(assignmentToUnremind);
 
         model.setAssignment(assignmentToUnremind, unremindedAssignment);

--- a/src/test/java/seedu/address/logic/commands/UnremindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnremindCommandTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showAssignmentAtIndex;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ASSIGNMENT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalAssignments.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ASSIGNMENT;
@@ -31,9 +29,9 @@ public class UnremindCommandTest {
     }
 
     @Test
-    public void execute_validIndexUnfilteredList_success() {
+    public void execute_validIndex_success() {
         remindFirstAssignment();
-        Assignment assignmentToUnremind = model.getFilteredAssignmentList().get(INDEX_FIRST_ASSIGNMENT.getZeroBased());
+        Assignment assignmentToUnremind = model.getRemindedAssignmentsList().get(INDEX_FIRST_ASSIGNMENT.getZeroBased());
         UnremindCommand unremindCommand = new UnremindCommand(INDEX_FIRST_ASSIGNMENT);
 
         String expectedMessage = String.format(
@@ -41,65 +39,17 @@ public class UnremindCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(),
                 model.getPreviousModel());
-        expectedModel.setAssignment(model.getFilteredAssignmentList().get(0), assignmentToUnremind);
+        expectedModel.setAssignment(model.getRemindedAssignmentsList().get(0), assignmentToUnremind);
 
         assertCommandSuccess(unremindCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredAssignmentList().size() + 1);
+    public void execute_invalidIndex_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getRemindedAssignmentsList().size() + 1);
         UnremindCommand unremindCommand = new UnremindCommand(outOfBoundIndex);
 
         assertCommandFailure(unremindCommand, model, Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void execute_validIndexFilteredList_success() {
-        showAssignmentAtIndex(model, INDEX_FIRST_ASSIGNMENT);
-
-        remindFirstAssignment();
-        model.updateFilteredAssignmentList(PREDICATE_SHOW_ALL_ASSIGNMENT);
-
-        Assignment assignmentToUnremind = model.getFilteredAssignmentList().get(INDEX_FIRST_ASSIGNMENT.getZeroBased());
-        UnremindCommand unremindCommand = new UnremindCommand(INDEX_FIRST_ASSIGNMENT);
-
-        String expectedMessage = String.format(
-                UnremindCommand.MESSAGE_UNREMIND_ASSIGNMENT_SUCCESS, assignmentToUnremind);
-
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), model.getPreviousModel());
-        expectedModel.setAssignment(model.getFilteredAssignmentList().get(0), assignmentToUnremind);
-
-        assertCommandSuccess(unremindCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
-        showAssignmentAtIndex(model, INDEX_FIRST_ASSIGNMENT);
-
-        Index outOfBoundIndex = INDEX_SECOND_ASSIGNMENT;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getAssignmentList().size());
-
-        UnremindCommand unremindCommand = new UnremindCommand(outOfBoundIndex);
-
-        assertCommandFailure(unremindCommand, model, Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
-    }
-
-    @Test
-    public void execute_alreadyUnremindedAssignmentUnfilteredList_failure() {
-        UnremindCommand unremindCommand = new UnremindCommand(INDEX_FIRST_ASSIGNMENT);
-
-        assertCommandFailure(unremindCommand, model, UnremindCommand.MESSAGE_UNREMINDED_ASSIGNMENT);
-    }
-
-    @Test
-    public void execute_alreadyUnremindedAssignmentFilteredList_failure() {
-        showAssignmentAtIndex(model, INDEX_FIRST_ASSIGNMENT);
-
-        UnremindCommand unremindCommand = new UnremindCommand(INDEX_FIRST_ASSIGNMENT);
-
-        assertCommandFailure(unremindCommand, model, UnremindCommand.MESSAGE_UNREMINDED_ASSIGNMENT);
     }
 
     @Test


### PR DESCRIPTION
closes #142 

Deleted test cases involving unfiltered and filtered lists as the unfiltered and filtered list is only relevant for commands working with the main assignment list.